### PR TITLE
In case of unicode response the content length header is not matching actual body length (because of the multibyte size diference)

### DIFF
--- a/test/helper.js
+++ b/test/helper.js
@@ -1,3 +1,18 @@
+Object.defineProperty(Object.prototype, "appendContextCollection", {
+  enumerable: false,
+  value: function(from) {
+    if (undefined !== from) {
+      var props = Object.getOwnPropertyNames(from);
+      var dest = this;
+      props.forEach(function(name) {
+        var destination = Object.getOwnPropertyDescriptor(from, name);
+        Object.defineProperty(dest, name, destination);
+      });
+    }
+    return this;
+  }
+});
+
 var assert = require('assert'),
     events = require('events'),
     Helper = (function() {
@@ -7,12 +22,21 @@ var assert = require('assert'),
                 assert.equal('text/plain', res.headers['content-type'], "Content Type should be text/plain");
                 assert.ok(res.headers['content-length'] > 0, 'Content Length should be set');
             },
-            getOptions: function() {
-                return {
-                    hostname: 'localhost',
-                    port: 4000,
-                    method: 'POST'
-                };
+            getOptions: function(options) {
+                var
+                    _options = {
+                        hostname: 'localhost',
+                        port: 4000,
+                        method: 'POST'
+                    };
+                    if (options !== undefined) {
+                        var props = Object.getOwnPropertyNames(options);
+                        props.forEach(function(name) {
+                            var destination = Object.getOwnPropertyDescriptor(options, name);
+                            Object.defineProperty(_options, name, destination);
+                        });
+                    }
+                return _options;
             },
             samplePostRequest: function(methodName, parameters, uid, mode) {
                 var req = {


### PR DESCRIPTION
Added options capabilities
Added the ability to set characterset
Added the option wather the unicode characters in the response must be
ASCII encoded (RFC 4627 - IETF)
